### PR TITLE
Update authors.js

### DIFF
--- a/models/authors.js
+++ b/models/authors.js
@@ -11,6 +11,8 @@ const BookSchema = new Schema({
 const AuthorSchema = new Schema({
     name: String,
     books: [BookSchema]
+    }, {
+    usePushEach: true
 });
 
 const Author = mongoose.model('author', AuthorSchema);


### PR DESCRIPTION
The $pushAll operator is no longer supported in Mongo 3.6.2 (or any newer versions from 3.6.x+).

You can do the following:

add the usePushEach: true option the Schema definition.
downgrade to Mongo 3.4.11(or any 3.4.x version)